### PR TITLE
Fix imports for newer versions of angular and NS

### DIFF
--- a/gif/gif.directive.ts
+++ b/gif/gif.directive.ts
@@ -1,6 +1,6 @@
 import {Directive, ElementRef, HostListener} from '@angular/core';
-import {knownFolders, path} from 'file-system';
-import {Image} from 'ui/image';
+import {knownFolders, path} from 'tns-core-modules/file-system';
+import {Image} from 'tns-core-modules/ui/image';
 
 import {toGif} from './image-to-gif';
 

--- a/gif/image-to-gif.android.ts
+++ b/gif/image-to-gif.android.ts
@@ -1,5 +1,5 @@
-import * as application from 'application';
-import {Image} from 'ui/image';
+import * as application from 'tns-core-modules/application';
+import {Image} from 'tns-core-modules/ui/image';
 
 declare const com: any
 declare const android: any;

--- a/gif/image-to-gif.d.ts
+++ b/gif/image-to-gif.d.ts
@@ -1,3 +1,3 @@
-import { Image } from 'ui/image';
+import { Image } from 'tns-core-modules/ui/image';
 
 export declare const toGif: (image: Image, absolutePath: string) => void;

--- a/gif/image-to-gif.ios.ts
+++ b/gif/image-to-gif.ios.ts
@@ -1,4 +1,4 @@
-import {Image} from 'ui/image';
+import {Image} from 'tns-core-modules/ui/image';
 
 declare const NSData: any;
 declare const AnimatedGif: any;


### PR DESCRIPTION
On install, module gives errors on import, because the path to the used imports changed.